### PR TITLE
Bump log4j-api from 2.15.0 to 2.16.0 in /bootstrap/standalone (#2700)

### DIFF
--- a/bootstrap/standalone/pom.xml
+++ b/bootstrap/standalone/pom.xml
@@ -11,7 +11,7 @@
     <artifactId>bootstrap-standalone</artifactId>
 
     <properties>
-        <log4j.version>2.15.0</log4j.version>
+        <log4j.version>2.16.0</log4j.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Bumps log4j-api from 2.15.0 to 2.16.0.

---
updated-dependencies:
- dependency-name: org.apache.logging.log4j:log4j-api
  dependency-type: direct:production
...

Signed-off-by: dependabot[bot] <support@github.com>

Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>